### PR TITLE
Theme(Creative): apply template across pages; map content; keep features

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,6 +16,9 @@
   <!-- Прогресс чтения -->
   <div id="readProgress" aria-hidden="true"></div>
 </header>
-<main class="wrap"><section class="hero"><h1>404</h1><p>Такой страницы нет. Вернуться на <a href="/">главную</a>.</p></section></main>
+<main class="wrap"><section class="hero"><h1>404</h1><p>Такой страницы нет. Вернуться на <a href="/">главную</a>.</p></section><div class="sticky-cta">
+  <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
+  <a href="/contacts.html" class="btn">Обсудить проект</a>
+</div></main>
 <footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub</p></footer>
 <script src="/assets/js/nav.js"></script></body></html>

--- a/calculator.html
+++ b/calculator.html
@@ -36,7 +36,10 @@
 <div class="card"><div class="small">Выручка</div><div id="kRev" style="font-size:22px;font-weight:800">—</div></div>
 <div class="card"><div class="small">Прибыль</div><div id="kProfit" style="font-size:22px;font-weight:800">—</div></div></div>
 <div class="card"><div class="small">ROMI</div><div id="kRomi" style="font-size:20px;font-weight:700">—</div></div>
-<canvas id="calcChart" class="mt-2" height="280"></canvas></div></div></main>
+<canvas id="calcChart" class="mt-2" height="280"></canvas></div></div><div class="sticky-cta">
+  <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
+  <a href="/contacts.html" class="btn">Обсудить проект</a>
+</div></main>
 <footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub</p></footer>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <script>

--- a/contacts.html
+++ b/contacts.html
@@ -33,7 +33,10 @@
 <div class="col card"><h2>Написать в Telegram</h2>
 <p><a class="btn" href="https://t.me/whioq" target="_blank">@whioq</a></p>
 <p class="small">Подсказка для копипаста:</p>
-<pre class="card">Привет, это компания &lt;название&gt;. Хочу обсудить проект по атрибуции и данным.</pre></div></div></main>
+<pre class="card">Привет, это компания &lt;название&gt;. Хочу обсудить проект по атрибуции и данным.</pre></div></div><div class="sticky-cta">
+  <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
+  <a href="/contacts.html" class="btn">Обсудить проект</a>
+</div></main>
 <footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub</p></footer>
 <script>
 const box=document.getElementById('formMsgResult');

--- a/index.html
+++ b/index.html
@@ -1,262 +1,210 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <title>Creative - Start Bootstrap Theme</title>
-        <!-- Favicon-->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
-        <!-- Bootstrap Icons-->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet" />
-        <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Merriweather+Sans:400,700" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic" rel="stylesheet" type="text/css" />
-        <!-- SimpleLightbox plugin CSS-->
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/SimpleLightbox/2.1.0/simpleLightbox.min.css" rel="stylesheet" />
-        <!-- Core theme CSS (includes Bootstrap)-->
-        <link rel="stylesheet" href="assets/css/main.css" />
-        <link rel="stylesheet" href="assets/theme/creative/theme.css" />
-    </head>
-    <body id="page-top">
-        <!-- Navigation-->
-        <nav class="navbar navbar-expand-lg navbar-light fixed-top py-3" id="mainNav">
-            <div class="container px-4 px-lg-5">
-                <a class="navbar-brand" href="#page-top">Start Bootstrap</a>
-                <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-                <div class="collapse navbar-collapse" id="navbarResponsive">
-                    <ul class="navbar-nav ms-auto my-2 my-lg-0">
-                        <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#portfolio">Portfolio</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
-                    </ul>
-                </div>
-            </div>
-        </nav>
-        <!-- Masthead-->
-        <header class="masthead">
-            <div class="container px-4 px-lg-5 h-100">
-                <div class="row gx-4 gx-lg-5 h-100 align-items-center justify-content-center text-center">
-                    <div class="col-lg-8 align-self-end">
-                        <h1 class="text-white font-weight-bold">Your Favorite Place for Free Bootstrap Themes</h1>
-                        <hr class="divider" />
-                    </div>
-                    <div class="col-lg-8 align-self-baseline">
-                        <p class="text-white-75 mb-5">Start Bootstrap can help you build better websites using the Bootstrap framework! Just download a theme and start customizing, no strings attached!</p>
-                        <a class="btn btn-primary btn-xl" href="#about">Find Out More</a>
-                    </div>
-                </div>
-            </div>
-        </header>
-        <!-- About-->
-        <section class="page-section bg-primary" id="about">
-            <div class="container px-4 px-lg-5">
-                <div class="row gx-4 gx-lg-5 justify-content-center">
-                    <div class="col-lg-8 text-center">
-                        <h2 class="text-white mt-0">We've got what you need!</h2>
-                        <hr class="divider divider-light" />
-                        <p class="text-white-75 mb-4">Start Bootstrap has everything you need to get your new website up and running in no time! Choose one of our open source, free to download, and easy to use themes! No strings attached!</p>
-                        <a class="btn btn-light btn-xl" href="#services">Get Started!</a>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <!-- Services-->
-        <section class="page-section" id="services">
-            <div class="container px-4 px-lg-5">
-                <h2 class="text-center mt-0">At Your Service</h2>
-                <hr class="divider" />
-                <div class="row gx-4 gx-lg-5">
-                    <div class="col-lg-3 col-md-6 text-center">
-                        <div class="mt-5">
-                            <div class="mb-2"><i class="bi-gem fs-1 text-primary"></i></div>
-                            <h3 class="h4 mb-2">Sturdy Themes</h3>
-                            <p class="text-muted mb-0">Our themes are updated regularly to keep them bug free!</p>
-                        </div>
-                    </div>
-                    <div class="col-lg-3 col-md-6 text-center">
-                        <div class="mt-5">
-                            <div class="mb-2"><i class="bi-laptop fs-1 text-primary"></i></div>
-                            <h3 class="h4 mb-2">Up to Date</h3>
-                            <p class="text-muted mb-0">All dependencies are kept current to keep things fresh.</p>
-                        </div>
-                    </div>
-                    <div class="col-lg-3 col-md-6 text-center">
-                        <div class="mt-5">
-                            <div class="mb-2"><i class="bi-globe fs-1 text-primary"></i></div>
-                            <h3 class="h4 mb-2">Ready to Publish</h3>
-                            <p class="text-muted mb-0">You can use this design as is, or you can make changes!</p>
-                        </div>
-                    </div>
-                    <div class="col-lg-3 col-md-6 text-center">
-                        <div class="mt-5">
-                            <div class="mb-2"><i class="bi-heart fs-1 text-primary"></i></div>
-                            <h3 class="h4 mb-2">Made with Love</h3>
-                            <p class="text-muted mb-0">Is it really open source if it's not made with love?</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <!-- Portfolio-->
-        <div id="portfolio">
-            <div class="container-fluid p-0">
-                <div class="row g-0">
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/1.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/1.jpg" alt="..." />
-                            <div class="portfolio-box-caption">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/2.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/2.jpg" alt="..." />
-                            <div class="portfolio-box-caption">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/3.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/3.jpg" alt="..." />
-                            <div class="portfolio-box-caption">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/4.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/4.jpg" alt="..." />
-                            <div class="portfolio-box-caption">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/5.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/5.jpg" alt="..." />
-                            <div class="portfolio-box-caption">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-lg-4 col-sm-6">
-                        <a class="portfolio-box" href="assets/theme/creative/img/portfolio/fullsize/6.jpg" title="Project Name">
-                            <img class="img-fluid" src="assets/theme/creative/img/portfolio/thumbnails/6.jpg" alt="..." />
-                            <div class="portfolio-box-caption p-3">
-                                <div class="project-category text-white-50">Category</div>
-                                <div class="project-name">Project Name</div>
-                            </div>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- Call to action-->
-        <section class="page-section bg-dark text-white">
-            <div class="container px-4 px-lg-5 text-center">
-                <h2 class="mb-4">Free Download at Start Bootstrap!</h2>
-                <a class="btn btn-light btn-xl" href="https://startbootstrap.com/theme/creative/">Download Now!</a>
-            </div>
-        </section>
-        <!-- Contact-->
-        <section class="page-section" id="contact">
-            <div class="container px-4 px-lg-5">
-                <div class="row gx-4 gx-lg-5 justify-content-center">
-                    <div class="col-lg-8 col-xl-6 text-center">
-                        <h2 class="mt-0">Let's Get In Touch!</h2>
-                        <hr class="divider" />
-                        <p class="text-muted mb-5">Ready to start your next project with us? Send us a messages and we will get back to you as soon as possible!</p>
-                    </div>
-                </div>
-                <div class="row gx-4 gx-lg-5 justify-content-center mb-5">
-                    <div class="col-lg-6">
-                        <!-- * * * * * * * * * * * * * * *-->
-                        <!-- * * SB Forms Contact Form * *-->
-                        <!-- * * * * * * * * * * * * * * *-->
-                        <!-- This form is pre-integrated with SB Forms.-->
-                        <!-- To make this form functional, sign up at-->
-                        <!-- https://startbootstrap.com/solution/contact-forms-->
-                        <!-- to get an API token!-->
-                        <form id="contactForm" data-sb-form-api-token="API_TOKEN">
-                            <!-- Name input-->
-                            <div class="form-floating mb-3">
-                                <input class="form-control" id="name" type="text" placeholder="Enter your name..." data-sb-validations="required" />
-                                <label for="name">Full name</label>
-                                <div class="invalid-feedback" data-sb-feedback="name:required">A name is required.</div>
-                            </div>
-                            <!-- Email address input-->
-                            <div class="form-floating mb-3">
-                                <input class="form-control" id="email" type="email" placeholder="name@example.com" data-sb-validations="required,email" />
-                                <label for="email">Email address</label>
-                                <div class="invalid-feedback" data-sb-feedback="email:required">An email is required.</div>
-                                <div class="invalid-feedback" data-sb-feedback="email:email">Email is not valid.</div>
-                            </div>
-                            <!-- Phone number input-->
-                            <div class="form-floating mb-3">
-                                <input class="form-control" id="phone" type="tel" placeholder="(123) 456-7890" data-sb-validations="required" />
-                                <label for="phone">Phone number</label>
-                                <div class="invalid-feedback" data-sb-feedback="phone:required">A phone number is required.</div>
-                            </div>
-                            <!-- Message input-->
-                            <div class="form-floating mb-3">
-                                <textarea class="form-control" id="message" type="text" placeholder="Enter your message here..." style="height: 10rem" data-sb-validations="required"></textarea>
-                                <label for="message">Message</label>
-                                <div class="invalid-feedback" data-sb-feedback="message:required">A message is required.</div>
-                            </div>
-                            <!-- Submit success message-->
-                            <!---->
-                            <!-- This is what your users will see when the form-->
-                            <!-- has successfully submitted-->
-                            <div class="d-none" id="submitSuccessMessage">
-                                <div class="text-center mb-3">
-                                    <div class="fw-bolder">Form submission successful!</div>
-                                    To activate this form, sign up at
-                                    <br />
-                                    <a href="https://startbootstrap.com/solution/contact-forms">https://startbootstrap.com/solution/contact-forms</a>
-                                </div>
-                            </div>
-                            <!-- Submit error message-->
-                            <!---->
-                            <!-- This is what your users will see when there is-->
-                            <!-- an error submitting the form-->
-                            <div class="d-none" id="submitErrorMessage"><div class="text-center text-danger mb-3">Error sending message!</div></div>
-                            <!-- Submit Button-->
-                            <div class="d-grid"><button class="btn btn-primary btn-xl disabled" id="submitButton" type="submit">Submit</button></div>
-                        </form>
-                    </div>
-                </div>
-                <div class="row gx-4 gx-lg-5 justify-content-center">
-                    <div class="col-lg-4 text-center mb-5 mb-lg-0">
-                        <i class="bi-phone fs-2 mb-3 text-muted"></i>
-                        <div>+1 (555) 123-4567</div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <!-- Footer-->
-        <footer class="bg-light py-5">
-            <div class="container px-4 px-lg-5"><div class="small text-center text-muted">Copyright &copy; 2023 - Company Name</div></div>
-        </footer>
-        <!-- Bootstrap core JS-->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-        <!-- SimpleLightbox plugin JS-->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/SimpleLightbox/2.1.0/simpleLightbox.min.js"></script>
-        <!-- Core theme JS-->
-        <script src="assets/theme/creative/theme.js"></script>
-        <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
-        <!-- * *                               SB Forms JS                               * *-->
-        <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->
-        <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
-        <script src="https://cdn.startbootstrap.com/sb-forms-latest.js"></script>
-    </body>
-</html>
+<!doctype html><html lang="ru"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SignalHub — от клика к сделке</title>
+<meta name="description" content="Сшиваем лиды и сделки с рекламой. Считаем вклад каналов в деньги и возвращаем сигналы в Ads.">
+<link rel="canonical" href="/">
+<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="/assets/theme/creative/theme.css">
+</head><body>
+<header>
+  <div class="wrap bar">
+    <div class="logo">SignalHub</div>
+    <button class="nav-toggle" id="navToggle" aria-label="Открыть меню" aria-expanded="false">☰</button>
+    <nav>
+      <a href="/">Главная</a>
+      <a href="/calculator.html">Генератор</a>
+      <a href="/projects.html">Проекты</a>
+      <a href="/contacts.html">Контакты</a>
+    </nav>
+  </div>
+  <!-- Прогресс чтения -->
+  <div id="readProgress" aria-hidden="true"></div>
+</header>
+<main class="wrap">
+<section class="hero"><h1>От клика к сделке — и обратно</h1>
+<p class="small">Сшиваем лиды, сделки и рекламу в один сигнал.</p>
+<p><a class="btn" href="/calculator.html">🚀 Запустить Генератор</a> <a class="btn" href="/projects.html">Кейсы и графики</a></p></section>
+<section class="benefit-bar grid">
+  <div class="metric card">
+    <div class="metric-num">–32%</div>
+    <div class="small">пустых расходов — за счёт честной атрибуции</div>
+  </div>
+  <div class="metric card">
+    <div class="metric-num">+28%</div>
+    <div class="small">ROMI — перераспределяем бюджет по сигналам</div>
+  </div>
+  <div class="metric card">
+    <div class="metric-num">1 хаб → 8</div>
+    <div class="small">Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, GA4, CRM, Call-tracking, Offline/POS</div>
+  </div>
+</section>
+<section class="tldr card">
+  Мы привязываем маркетинг к деньгам.
+  Пиксели — мнение, сделка — факт. Подключаем источники → сшиваем → атрибутируем → шлём ценность обратно в Ads.
+  Итог: меньше слива, больше прибыли.
+</section>
+<section class="intro">
+  <p>Мы берем хаос кликов и баннеров и складываем его в одну понятную историю: от рекламного бюджета → к лидам → к сделкам → к деньгам. Без мистики. Только факты.</p>
+  <p>Пиксели могут «потеряться»: блокировки, куки, разные устройства. Сделка — нет. В CRM у сделки есть дата, сумма и статус «оплачено». Вот поэтому мы доверяем сделкам, а не пикселям.</p>
+  <p>Мы подключаем рекламные кабинеты, аналитику, сайт и CRM, выравниваем события, сшиваем лиды со сделками, выбираем модель атрибуции под ваш бизнес и отправляем «правильные» сигналы обратно в Ads.</p>
+  <p>В итоге бухгалтер перестает морщиться, маркетолог — угадывать, а руководитель — спорить с пикселем. Все видят одну картину и говорят на языке «сколько заработали» — а не «сколько показов».</p>
+</section>
+
+<section class="flow">
+  <h2>Как это работает</h2>
+  <div class="grid">
+    <div class="card"><span role="img" aria-label="data">📊</span> Собираем данные — реклама, сайт, CRM, звонки, офлайн.</div>
+    <div class="card"><span role="img" aria-label="merge">🧩</span> Сшиваем лиды и сделки — убираем дубли, приводим к одной схеме.</div>
+    <div class="card"><span role="img" aria-label="fair">⚖️</span> Честная атрибуция — считаем вклад каналов в реальные деньги.</div>
+    <div class="card"><span role="img" aria-label="ads">🔁</span> Возвращаем сигналы в Ads — алгоритмы учатся на выручке.</div>
+  </div>
+</section>
+
+<h2>Почему пикселям верить нельзя, а сделкам — можно</h2>
+<div class="grid">
+  <div class="card"><strong>Cookies ломаются</strong><br><span class="small">Блокировщики и приватность рвут цепочку кликов — часть пути теряется.</span></div>
+  <div class="card"><strong>Сделки подтверждены</strong><br><span class="small">CRM и бухгалтерия фиксируют факт оплаты — это и есть реальность.</span></div>
+  <div class="card"><strong>Атрибуция на событиях</strong><br><span class="small">Сшиваем лиды, сделки и выручку — считаем вклад каналов честно.</span></div>
+  <div class="card"><strong>Сигналы обратно в Ads</strong><br><span class="small">Обучаем алгоритмы на настоящих деньгах, а не на «похожих кликах».</span></div>
+  <div class="card"><strong>Один человек — три устройства</strong><br><span class="small">Телефон, ноутбук, планшет. Пиксель путается, сделка — нет.</span></div>
+  <div class="card"><strong>Последний клик — не последнее слово</strong><br><span class="small">Часто «лавры» забирает ретаргет, хотя работали верхние каналы.</span></div>
+  <div class="card"><strong>UTM бывают хрупкими</strong><br><span class="small">Менеджер поменял метку — и полотна данных врозь. Сделка всё склеит.</span></div>
+  <div class="card"><strong>Окна атрибуции ≠ правда</strong><br><span class="small">7 дней тут, 28 — там. Сделка не зависит от настроек чужих систем.</span></div>
+  <div class="card"><strong>Боты не покупают</strong><br><span class="small">Клики и «подозрительные лиды» надувают отчёт, но не счёт в банке.</span></div>
+</div>
+<section class="mv">
+  <h2>Миф vs Реальность</h2>
+  <div class="grid">
+    <details class="card">
+      <summary><strong>Миф:</strong> «Последний клик — король»</summary>
+      <div class="small"><strong>Реальность:</strong> он часто лишь завершает чужую работу. Верхние каналы недооценены — мы это показываем.</div>
+    </details>
+    <details class="card">
+      <summary><strong>Миф:</strong> «CTR растёт — всё отлично»</summary>
+      <div class="small"><strong>Реальность:</strong> боты кликают лучше людей. Мы считаем то, что платит — сделки и прибыль.</div>
+    </details>
+    <details class="card">
+      <summary><strong>Миф:</strong> «UTM всё спасут»</summary>
+      <div class="small"><strong>Реальность:</strong> метки хрупкие. Сделка в CRM склеит картину, даже если метки гуляют.</div>
+    </details>
+    <details class="card">
+      <summary><strong>Миф:</strong> «На Pixel всё видно»</summary>
+      <div class="small"><strong>Реальность:</strong> кросс-девайс и блокировщики ломают трекинг. Сделку не сломать.</div>
+    </details>
+  </div>
+</section>
+
+<section class="mini-calc">
+  <h2>Поиграйтесь и посмотрите результат</h2>
+  <div class="sliders">
+    <label for="mcBudget">Месячный бюджет, € — <span id="mcBudgetVal">10&nbsp;000</span><input type="range" id="mcBudget" aria-label="Месячный бюджет" min="1000" max="100000" step="500" value="10000"></label>
+    <label for="mcCpl">Стоимость лида, € — <span id="mcCplVal">50</span><input type="range" id="mcCpl" aria-label="Стоимость лида" min="5" max="300" step="5" value="50"></label>
+    <label for="mcConv">Конверсия лид→сделка, % — <span id="mcConvVal">12</span><input type="range" id="mcConv" aria-label="Конверсия лид в сделку" min="1" max="50" step="1" value="12"></label>
+    <label for="mcAov">Средний чек, € — <span id="mcAovVal">1&nbsp;000</span><input type="range" id="mcAov" aria-label="Средний чек" min="500" max="20000" step="100" value="1000"></label>
+  </div>
+  <div class="row results mt-2">
+    <div class="card"><div id="mcLeads" class="calc-num" aria-live="polite">200</div><div class="small">Лиды</div></div>
+    <div class="card"><div id="mcDeals" class="calc-num" aria-live="polite">24</div><div class="small">Сделки</div></div>
+    <div class="card"><div id="mcRev" class="calc-num" aria-live="polite">24&nbsp;000</div><div class="small">Оборот</div></div>
+  </div>
+  <p class="small">Это приблизительная оценка. За деталями — <a href="/calculator.html">Генератор</a>.</p>
+</section>
+
+<section class="cases">
+  <h2>Пара кейсов</h2>
+  <div class="grid">
+    <a class="card case" href="/projects.html">
+      <div>Авто-ритейл — остановили пожирателя бюджета, выручка пошла вверх</div>
+      <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
+        <polyline class="cost" points="0,14 20,13 40,12 60,11"></polyline>
+        <polyline class="rev" points="0,10 20,11 40,14 60,17"></polyline>
+      </svg>
+    </a>
+    <a class="card case" href="/projects.html">
+      <div>Электроника — разгрузили ретаргет, открыли новые точки роста</div>
+      <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
+        <polyline class="cost" points="0,14 20,13 40,12 60,11"></polyline>
+        <polyline class="rev" points="0,10 20,11 40,14 60,17"></polyline>
+      </svg>
+    </a>
+    <a class="card case" href="/projects.html">
+      <div>B2B-услуги — сигналы с высокими чеками дали кратный эффект</div>
+      <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
+        <polyline class="cost" points="0,14 20,13 40,12 60,11"></polyline>
+        <polyline class="rev" points="0,10 20,11 40,14 60,17"></polyline>
+      </svg>
+    </a>
+  </div>
+</section>
+
+<section class="story">
+  <h2>Жизнь одного лида</h2>
+  <div class="story-strip">
+    <div class="card story-step"><strong>Увидел рекламу</strong><br><span class="small">Запомнил оффер и ушёл думать.</span></div>
+    <div class="card story-step"><strong>Оставил лид</strong><br><span class="small">Заявка попала в CRM.</span></div>
+    <div class="card story-step"><strong>Созвонились</strong><br><span class="small">Менеджер уточнил детали.</span></div>
+    <div class="card story-step"><strong>Сделка</strong><br><span class="small">Оплата прошла успешно.</span></div>
+    <div class="card story-step"><strong>Выручка зафиксирована</strong><br><span class="small">Ценность — итог всей цепочки, не только последнего касания.</span></div>
+  </div>
+</section>
+
+<section class="cta">
+  <h2>Готовы менять пиксели на деньги?</h2>
+  <p>SignalHub — это хаб для всех источников: реклама, сайт, CRM. Все сигналы сходятся в одну картину, где видно, что реально продаёт.</p>
+  <p>Мы экономим бюджет и время: отключаем то, что не работает, масштабируем то, что тянет выручку, и возвращаем в рекламные системы сигналы, на которые они должны учиться.</p>
+  <p>Лиды не теряются — они сходятся. Данные начинают работать как команда: меньше догадок, больше прибыли. Бухгалтер улыбается. Пиксель — тоже, но уже по делу.</p>
+  <ul class="grid">
+    <li class="card">Меньше слива бюджета за счёт честной атрибуции.</li>
+    <li class="card">Правильное масштабирование каналов — без «мифа последнего клика».</li>
+    <li class="card">Единый хаб данных вместо десятка разрозненных отчётов.</li>
+    <li class="card">Сигналы обратно в Ads — быстрее обучаются и дешевле приводят сделки.</li>
+  </ul>
+  <p><a href="/calculator.html" class="btn">🚀 Запустить Генератор</a> <a href="/contacts.html" class="btn">Обсудить проект</a></p>
+</section>
+
+<section class="faq">
+  <h2>FAQ</h2>
+  <div class="grid">
+    <details class="card"><summary>Мы без CRM — это проблема?</summary><div class="small">Можно стартовать и без неё: временную схему соберём из того, что есть. Но чем раньше появится CRM, тем быстрее увидим полный путь денег и сможем точнее считать результат.</div></details>
+    <details class="card"><summary>Лиды офлайн/по телефону — это учитывается?</summary><div class="small">Да. Подключаем коллтрекинг, выгружаем офлайн-продажи и связываем их с рекламой. Так видим всю картину, а не только то, что случилось на сайте.</div></details>
+    <details class="card"><summary>Кросс-девайс нас убьёт?</summary><div class="small">Пиксель часто теряет связь между устройствами, из‑за чего в отчётах пустые дыры. Мы опираемся на сделку: её не потерять даже если путь шёл через телефон, ноутбук и офлайн-точку.</div></details>
+    <details class="card"><summary>Сроки запуска?</summary><div class="small">Базовая интеграция занимает считанные дни — подключаем источники и выравниваем события. Глубокая настройка и тестирование моделей атрибуции обсуждаются отдельно и зависят от готовности данных.</div></details>
+    <details class="card"><summary>Нужны ли разработчики?</summary><div class="small">Большую часть работ закрываем сами, вам остаётся дать доступы и иногда поставить код. Если есть внутренняя команда, взаимодействуем через короткие понятные задачи.</div></details>
+    <details class="card"><summary>Это окупается?</summary><div class="small">Мы не обещаем чудес, но показываем цифры. Отсекая лишние расходы и усиливая рабочие каналы, бизнес обычно видит экономию и рост уже в первые месяцы.</div></details>
+    <details class="card"><summary>Если аналитика уже настроена?</summary><div class="small">Отлично. Мы не ломаем текущие отчёты, а дополняем их слоем «сделки → выручка → сигналы», который связывает маркетинг с реальными деньгами.</div></details>
+    <details class="card"><summary>Работаете с чувствительными данными?</summary><div class="small">Да. Используем защищённые каналы, заключаем договоры и соблюдаем все требования законодательства. Никаких серых схем или передачи данных третьим лицам.</div></details>
+  </div>
+</section>
+
+<section class="limits">
+  <h2>Честно о границах метода</h2>
+  <p>Мы не рисуем чудес. Если продукт не покупают — дело не в пикселях. Но если покупают — мы покажем, откуда пришли деньги и где ускоряться.</p>
+  <ul>
+    <li>Не обещаем «в 10 раз за неделю» — обещаем прозрачность.</li>
+    <li>Если данные хаос — сначала приводим их в порядок.</li>
+    <li>Решения принимаем по сделкам и выручке, не по лайкам.</li>
+  </ul>
+</section>
+
+<section class="works">
+  <h2>Работает с</h2>
+  <p class="works-list">
+    <span class="badge">Google Ads</span>
+    <span class="badge">Meta Ads</span>
+    <span class="badge">TikTok Ads</span>
+    <span class="badge">LinkedIn Ads</span>
+    <span class="badge">GA4</span>
+    <span class="badge">CRM</span>
+    <span class="badge">Call-tracking</span>
+    <span class="badge">Offline/POS</span>
+  </p>
+  <p class="small">Если вашего инструмента нет — уточните, вероятно подключим</p>
+</section>
+
+<div class="sticky-cta">
+  <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
+  <a href="/contacts.html" class="btn">Обсудить проект</a>
+</div>
+</main>
+<footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub · от клика к выручке</p></footer>
+<script src="/assets/js/nav.js"></script></body></html>

--- a/projects.html
+++ b/projects.html
@@ -18,7 +18,10 @@
   <div id="readProgress" aria-hidden="true"></div>
 </header>
 <main class="wrap"><h1>Проекты</h1><p class="small">Кейсы анонимизированы; важны закономерности. На графике: слева — рекламные затраты, справа — прибыль.</p>
-<div id="cases"></div></main>
+<div id="cases"></div><div class="sticky-cta">
+  <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
+  <a href="/contacts.html" class="btn">Обсудить проект</a>
+</div></main>
 <footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub</p></footer>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- Reinstate Creative-themed homepage with metrics, pixel skepticism, myth-vs-reality accordion, mini calculator, case teasers, scroll story, FAQ, honest limits and works-with badges
- Link Creative CSS and keep sticky CTA, reading progress and active mobile burger across all pages
- Add sticky CTAs to subpages for quick access to calculator and contact

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68bd5680ee80832e8c7cb1c6f6dbb053