### PR TITLE
fix: enable contact form email and cleanup copy text

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -20,7 +20,7 @@
 <main class="wrap"><h1>Контакты</h1>
 <p class="small">Отвечаем на любых языках, текстом. Созвоны и онлайн-встречи — только для обсуждения проекта. Сохраняем интригу: оставляем за собой право не отвечать на неинтересные запросы — без обид, ок?</p>
 <div class="row"><div class="col card"><h2>Отправить сообщение</h2>
-<form id="formMsg">
+<form id="formMsg" action="https://formsubmit.co/printplus10@gmail.com" method="POST">
 <label>Имя<br><input name="name" required style="width:100%;padding:10px"></label>
 <label class="mt-1">Компания (опц.)<br><input name="company" style="width:100%;padding:10px"></label>
 <label class="mt-1">Email<br><input type="email" name="email" required style="width:100%;padding:10px"></label>
@@ -28,19 +28,32 @@
 <label class="mt-1">Сообщение<br><textarea name="message" rows="5" required style="width:100%;padding:10px"></textarea></label>
 <label class="mt-1"><input type="checkbox" required> Согласен на обработку данных</label>
 <button class="btn mt-1" type="submit">Отправить</button></form>
-<div id="formMsgResult" class="hidden mt-1"></div>
-<p class="small">Email приёма заявок настроим на backend: <em>printplus10@gmail.com</em> (не публикуем на сайте).</p></div>
+<div id="formMsgResult" class="hidden mt-1"></div></div>
 <div class="col card"><h2>Написать в Telegram</h2>
-<p><a class="btn" href="https://t.me/whioq" target="_blank">@whioq</a></p>
-<p class="small">Подсказка для копипаста:</p>
-<pre class="card">Привет, это компания &lt;название&gt;. Хочу обсудить проект по атрибуции и данным.</pre></div></div><div class="sticky-cta">
+<p><a class="btn" href="https://t.me/whioq" target="_blank">@whioq</a></p></div></div><div class="sticky-cta">
   <a href="/calculator.html" class="btn">🚀 Посчитать сейчас</a>
   <a href="/contacts.html" class="btn">Обсудить проект</a>
 </div></main>
 <footer class="wrap"><p class="small">© <script>document.write(new Date().getFullYear())</script> SignalHub</p></footer>
 <script>
 const box=document.getElementById('formMsgResult');
-document.getElementById('formMsg').addEventListener('submit',e=>{e.preventDefault();box.className='card';box.textContent='Спасибо! Сообщение принято. Мы свяжемся, если это наш тип задачи.';e.target.reset();});
+document.getElementById('formMsg').addEventListener('submit',async e=>{
+  e.preventDefault();
+  const data=new FormData(e.target);
+  box.className='card';
+  box.textContent='Отправка...';
+  try{
+    const r=await fetch('https://formsubmit.co/ajax/printplus10@gmail.com',{method:'POST',body:data,headers:{'Accept':'application/json'}});
+    if(r.ok){
+      box.textContent='Спасибо! Сообщение принято. Мы свяжемся, если это наш тип задачи.';
+      e.target.reset();
+    }else{
+      box.textContent='Ошибка отправки. Попробуйте позже.';
+    }
+  }catch(err){
+    box.textContent='Ошибка отправки. Попробуйте позже.';
+  }
+});
 </script>
 <script src="/assets/theme/creative/theme.js"></script>
 <script src="/assets/js/nav.js"></script></body></html>


### PR DESCRIPTION
## Summary
- wire contact form to submit via formsubmit and show status
- remove visible email and copy-paste hints from contacts page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80af42d78832e90d23aab0683841d