### PR TITLE
Add Google Analytics tracking snippet

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,13 @@
 <!doctype html><html lang="ru"><head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9W93MFG4YF');
+</script>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Страница не найдена — SignalHub</title>
 <link rel="stylesheet" href="assets/css/main.css"><link rel="stylesheet" href="assets/theme/creative/theme.css"></head><body>

--- a/README.md
+++ b/README.md
@@ -34,5 +34,21 @@ SignalHub показывает, что *на самом деле* приноси
 
 ---
 
-🚀 Deployed on [Cloudflare Pages](https://pages.cloudflare.com/)  
+🚀 Deployed on [Cloudflare Pages](https://pages.cloudflare.com/)
 📊 Engineered for clarity, speed, and scale.
+
+## Development notes
+
+- Все HTML-страницы должны содержать Google Analytics-тег сразу после открытия тега `<head>`:
+
+  ```html
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+  <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9W93MFG4YF');
+  </script>
+  ```

--- a/calculator.html
+++ b/calculator.html
@@ -1,4 +1,13 @@
 <!doctype html><html lang="ru"><head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9W93MFG4YF');
+</script>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Генератор — SignalHub</title>
 <meta name="description" content="Подвигай ползунки и посмотри, как меняются лиды, сделки, выручка и ROMI.">

--- a/contacts.html
+++ b/contacts.html
@@ -1,4 +1,13 @@
 <!doctype html><html lang="ru"><head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9W93MFG4YF');
+</script>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Контакты — SignalHub</title>
 <meta name="description" content="Отвечаем на любых языках, текстом. Созвоны — только для обсуждения проекта. Сохраняем интригу.">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="ru">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-9W93MFG4YF');
+  </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>SignalHub — от клика к сделке</title>

--- a/projects.html
+++ b/projects.html
@@ -1,4 +1,13 @@
 <!doctype html><html lang="ru"><head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9W93MFG4YF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9W93MFG4YF');
+</script>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Проекты — SignalHub</title>
 <meta name="description" content="Пять кейсов: авто, электроника, услуги, офлайн, B2B. Таблицы и графики: слева затраты, справа прибыль.">


### PR DESCRIPTION
## Summary
- add the Google Analytics tag to every existing HTML page directly after the head element
- document the requirement in the README so future pages include the same snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d937f61914832e879c80116ee74347