### PR TITLE
Add first-visit notice and update case navigation

### DIFF
--- a/assets/sh.css
+++ b/assets/sh.css
@@ -22,6 +22,48 @@ body{
   text-rendering:optimizeLegibility;
 }
 
+.sh-notice{
+  position:relative;
+  background:linear-gradient(135deg,#b6242d,#7d1217 65%);
+  color:#fff;
+  border-bottom:1px solid rgba(255,255,255,.18);
+  box-shadow:0 8px 24px rgba(38,6,8,.25);
+  z-index:40;
+}
+
+.sh-notice .sh-wrap{
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+  align-items:flex-start;
+  padding-block:clamp(18px,4vw,26px);
+}
+
+.sh-notice p{color:#fff;margin:0;max-width:60ch;font-size:.95rem;line-height:1.55}
+
+.sh-notice-close{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  background:rgba(0,0,0,.18);
+  color:#fff;
+  border:1px solid rgba(255,255,255,.35);
+  border-radius:999px;
+  padding:10px 18px;
+  font-weight:600;
+  cursor:pointer;
+  transition:background var(--sh-speed) var(--sh-ease),transform 160ms ease;
+}
+
+.sh-notice-close:hover{background:rgba(0,0,0,.28)}
+.sh-notice-close:focus-visible{outline:2px solid #fff;outline-offset:3px}
+.sh-notice-close:active{transform:scale(.98)}
+
+@media (min-width:720px){
+  .sh-notice .sh-wrap{flex-direction:row;align-items:center;justify-content:space-between}
+  .sh-notice p{font-size:1rem}
+}
+
 body::after{
   content:"";
   position:fixed;
@@ -166,13 +208,16 @@ body.nav-open .nav-toggle span:nth-child(2){opacity:0}
 body.nav-open .nav-toggle span:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
 
 #readProgress{
-  position:absolute;
-  inset:auto 0 0;
+  position:fixed;
+  top:0;
+  left:0;
+  right:auto;
   height:3px;
   background:linear-gradient(90deg,var(--sh-accent),var(--sh-accent-2));
   transform-origin:left;
   width:0;
   border-radius:999px;
+  z-index:60;
 }
 
 .sh-hero{
@@ -310,6 +355,9 @@ body.nav-open .nav-toggle span:nth-child(3){transform:translateY(-7px) rotate(-4
 .sh-integrations .logo:hover{transform:translateY(-4px);border-color:var(--sh-accent)}
 .sh-integrations .logo:hover::after{opacity:.5}
 .sh-integrations .logo img{max-width:120px;height:auto;filter:drop-shadow(0 8px 18px rgba(110,139,255,.2))}
+.sh-integrations .sh-section-head,.sh-integrations .works-list,.sh-integrations .small{text-align:center}
+.sh-integrations .works-list{display:flex;flex-wrap:wrap;justify-content:center;gap:10px 14px;margin-top:clamp(10px,2vw,16px)}
+.sh-integrations .works-list .badge{margin:0}
 
 .sticky-cta{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);display:flex;gap:12px;background:rgba(12,16,22,.9);padding:12px 18px;border-radius:999px;box-shadow:0 20px 45px rgba(6,10,18,.45);border:1px solid rgba(110,139,255,.18);backdrop-filter:blur(12px);z-index:30;transition:opacity var(--sh-speed) var(--sh-ease),transform var(--sh-speed) var(--sh-ease)}
 .sticky-cta .btn{padding-inline:18px}

--- a/assets/sh.js
+++ b/assets/sh.js
@@ -52,6 +52,43 @@
     });
   }
 
+  // Specialist notice for first-time visitors
+  const notice = doc.getElementById('specialistNotice');
+  const noticeClose = doc.getElementById('specialistNoticeClose');
+  const noticeKey = 'sh-specialist-notice';
+  const getStore = () => {
+    const stores = [window.localStorage, window.sessionStorage];
+    for (const store of stores) {
+      if (!store) continue;
+      try {
+        const testKey = '__shNoticeTest__';
+        store.setItem(testKey, '1');
+        store.removeItem(testKey);
+        return store;
+      } catch (error) {
+        continue;
+      }
+    }
+    return null;
+  };
+  const store = getStore();
+  const hasSeenNotice = store ? store.getItem(noticeKey) === '1' : false;
+  if (notice && noticeClose && !hasSeenNotice) {
+    notice.hidden = false;
+    notice.classList.add('is-active');
+    noticeClose.addEventListener('click', () => {
+      notice.classList.remove('is-active');
+      notice.setAttribute('hidden', '');
+      if (store) {
+        try {
+          store.setItem(noticeKey, '1');
+        } catch (error) {
+          /* noop */
+        }
+      }
+    });
+  }
+
   // Reading progress
   const progress = doc.getElementById('readProgress');
   const main = doc.getElementById('main-content');

--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
   <script defer src="/assets/sh.js"></script>
 </head>
 <body>
+  <div class="sh-notice" id="specialistNotice" role="region" aria-live="polite" hidden>
+    <div class="sh-wrap">
+      <p>Материалы на сайте имеют узкую профессиональную направленность и предназначены только для специалистов.</p>
+      <button type="button" class="sh-notice-close" id="specialistNoticeClose" aria-label="Закрыть предупреждение">Понятно</button>
+    </div>
+  </div>
   <header class="sh-hero" data-section="hero">
     <div class="sh-hero-bg" aria-hidden="true">
       <div class="sh-hero-grid"></div>
@@ -184,7 +190,7 @@
           <h2>Пара кейсов</h2>
         </div>
         <div class="grid">
-          <a class="card case reveal" href="/projects.html">
+          <a class="card case reveal" href="/projects.html#auto">
             <div class="case-media"><img src="/assets/showcase-retail.svg" alt="Рост выручки в авто-ритейле" loading="lazy" decoding="async"></div>
             <div>Авто-ритейл — остановили пожирателя бюджета, выручка пошла вверх</div>
             <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
@@ -192,7 +198,7 @@
               <polyline class="rev" points="0,10 20,11 40,14 60,17"></polyline>
             </svg>
           </a>
-          <a class="card case reveal" href="/projects.html">
+          <a class="card case reveal" href="/projects.html#electronics">
             <div class="case-media"><img src="/assets/showcase-growth.svg" alt="Диаграмма по электронике" loading="lazy" decoding="async"></div>
             <div>Электроника — разгрузили ретаргет, открыли новые точки роста</div>
             <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
@@ -200,7 +206,7 @@
               <polyline class="rev" points="0,10 20,11 40,14 60,17"></polyline>
             </svg>
           </a>
-          <a class="card case reveal" href="/projects.html">
+          <a class="card case reveal" href="/projects.html#b2b">
             <div class="case-media"><img src="/assets/showcase-b2b.svg" alt="График по B2B" loading="lazy" decoding="async"></div>
             <div>B2B-услуги — сигналы с высокими чеками дали кратный эффект</div>
             <svg class="spark" viewBox="0 0 60 24" aria-hidden="true">
@@ -268,8 +274,8 @@
           <h2>Честно о границах метода</h2>
           <p>Мы не рисуем чудес. Если продукт не покупают — дело не в пикселях. Но если покупают — мы покажем, откуда пришли деньги и где ускоряться.</p>
           <ul>
-            <li>Не обещаем «в 10 раз за неделю» — обещаем прозрачность.</li>
-            <li>Если данные хаос — сначала приводим их в порядок.</li>
+            <li>Не обещаем x2 за неделю, но обещаем прозрачность: если данные — хаос, начинаем с их наведения порядка.</li>
+            <li>Приводим разношёрстные источники к одной схеме, прежде чем считать эффективность.</li>
             <li>Решения принимаем по сделкам и выручке, не по лайкам.</li>
           </ul>
         </div>
@@ -303,7 +309,7 @@
           <div class="logo"><img src="/assets/logos/logo-offline.svg" alt="Логотип Offline Capture" loading="lazy" decoding="async"></div>
           <div class="logo"><img src="/assets/logos/logo-call.svg" alt="Логотип Call Flow" loading="lazy" decoding="async"></div>
         </div>
-        <p class="small reveal">Если вашего инструмента нет в списке — уточните, скорее всего подключим</p>
+        <p class="small reveal">Не работаем с недвижимостью и модой.</p>
       </div>
     </section>
   </main>

--- a/projects.html
+++ b/projects.html
@@ -50,7 +50,9 @@ cases.forEach(cs=>{
     const profit=Math.round(rev*cs.margin - spend); const romi=profit/spend;
     return {year:y, spend, leads, conv:cs.conv, deals, aov:cs.aov, rev, margin:cs.margin, profit, romi};
   });
-  const wrap=document.createElement('section'); wrap.className='card mt-2';
+  const wrap=document.createElement('section');
+  wrap.className='card mt-2';
+  wrap.id = cs.key;
   wrap.innerHTML=`
     <h2>${cs.title}</h2>
     <div class="row">


### PR DESCRIPTION
## Summary
- add a first-visit specialist notice banner, including storage-backed dismissal logic and progress bar repositioning
- retarget the home page case links to project-specific anchors and refine the limits copy and integrations messaging
- center the integrations section layout and expose per-case anchors on the projects page for direct linking

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e27299ca94832eba3d2d80c6a40f50